### PR TITLE
update the owner of raw db & move nyt_cases to source

### DIFF
--- a/secure/roles.yml
+++ b/secure/roles.yml
@@ -60,6 +60,8 @@
       - z_wh_loading
       - z_db_starschema_covid19
     owns:
+      databases:
+        - raw
       schemas:
         - raw.*
 
@@ -84,7 +86,6 @@
       databases:
         - balboa
         - balboa_dev
-        - raw
       schemas:
         - balboa.*
 

--- a/transform/models/bays/bay_covid/base_cases.yml
+++ b/transform/models/bays/bay_covid/base_cases.yml
@@ -1,26 +1,5 @@
 version: 2
 
-sources:
-  - name: nyt_covid
-    database: raw
-    schema: raw
-    tags:
-      - daily_morning
-    tables:
-      - name: nyt_covid_data
-        description: >
-          RAW <a href="https://github.com/nytimes/covid-19-data/" target="_blank">Covid information from the NYT</a>
-        identifier: _AIRBYTE_RAW_NYT_COVID_DATA
-        columns:
-          - name: _airbyte_ab_id
-            descrition: "Airbyte's unitque identifier for this record"
-            tests:
-              - not_null
-          - name: _airbyte_data
-            description: VARIAN Column containing source data
-          - name: _airbyte_emitted_at
-            descrition: Airbyte ingestions timestampt for this record
-
 models:
   - name: base_cases
     description: Covid information from the NYT

--- a/transform/models/sources/nyt_covid_cases/nyt_covid_cases.yml
+++ b/transform/models/sources/nyt_covid_cases/nyt_covid_cases.yml
@@ -1,0 +1,22 @@
+version: 2
+
+sources:
+  - name: nyt_covid
+    database: raw
+    schema: raw
+    tags:
+      - daily_morning
+    tables:
+      - name: nyt_covid_data
+        description: >
+          RAW <a href="https://github.com/nytimes/covid-19-data/" target="_blank">Covid information from the NYT</a>
+        identifier: _AIRBYTE_RAW_NYT_COVID_DATA
+        columns:
+          - name: _airbyte_ab_id
+            descrition: "Airbyte's unitque identifier for this record"
+            tests:
+              - not_null
+          - name: _airbyte_data
+            description: VARIAN Column containing source data
+          - name: _airbyte_emitted_at
+            descrition: Airbyte ingestions timestampt for this record


### PR DESCRIPTION
* make loader role owner of raw db
* move the source definition for nyt_covid data to source folder vs bay