### PR TITLE
Dcv 1799 allow links in dbt docs

### DIFF
--- a/automate/dbt/open_dbt_docs_links_new_tab.py
+++ b/automate/dbt/open_dbt_docs_links_new_tab.py
@@ -13,26 +13,27 @@ if not dbt_docs_index_path.exists():
     console.print(
         "[red]:cross_mark:[/red] DBT docs not found, run [i]'dbt docs generate'[/i] in your project folder"
     )
-    exit(1)
-
-with open(dbt_docs_index_path, "r") as f:
-    html_content = f.read()
-
-new_tab_tag = "<base target='_blank'>"
-
-head_start = html_content.find("<head>") + len("<head>")
-head_end = html_content.find("</head>")
-
-if new_tab_tag not in html_content[head_start:head_end]:
-    modified_content = html_content[:head_end] + new_tab_tag + html_content[head_end:]
-
-    # Write the modified content back to the HTML file
-    with open(dbt_docs_index_path, "w") as html_file:
-        html_file.write(modified_content)
-    console.print(
-        "[green]:heavy_check_mark:[/green] dbt docs links will now open in a new tab"
-    )
 else:
-    console.print(
-        "[red]:cross_mark:[/red] dbt-docs links are already being opened in a new tab."
-    )
+    with open(dbt_docs_index_path, "r") as f:
+        html_content = f.read()
+
+    new_tab_tag = "<base target='_blank'>"
+
+    head_start = html_content.find("<head>") + len("<head>")
+    head_end = html_content.find("</head>")
+
+    if new_tab_tag not in html_content[head_start:head_end]:
+        modified_content = (
+            html_content[:head_end] + new_tab_tag + html_content[head_end:]
+        )
+
+        # Write the modified content back to the HTML file
+        with open(dbt_docs_index_path, "w") as html_file:
+            html_file.write(modified_content)
+        console.print(
+            "[green]:heavy_check_mark:[/green] dbt docs links will now open in a new tab"
+        )
+    else:
+        console.print(
+            "[red]:cross_mark:[/red] dbt docs links are already being opened in a new tab."
+        )

--- a/automate/dbt/open_dbt_docs_links_new_tab.py
+++ b/automate/dbt/open_dbt_docs_links_new_tab.py
@@ -1,0 +1,26 @@
+import os
+from pathlib import Path
+
+DBT_HOME = os.environ.get("DBT_HOME", "/config/workspace/transform")
+
+dbt_docs_index_path = Path(f"{DBT_HOME}/target/index.html")
+
+if not dbt_docs_index_path.exists():
+    raise Exception("DBT docs not generated")
+
+with open(dbt_docs_index_path, "r") as f:
+    html_content = f.read()
+
+new_tab_tag = "<base target='_blank'>"
+
+head_start = html_content.find("<head>") + len("<head>")
+head_end = html_content.find("</head>")
+
+if new_tab_tag not in html_content[head_start:head_end]:
+    modified_content = html_content[:head_end] + new_tab_tag + html_content[head_end:]
+
+    # Write the modified content back to the HTML file
+    with open(dbt_docs_index_path, "w") as html_file:
+        html_file.write(modified_content)
+else:
+    print("New-tab tag already exists in the dbt-docs page.")

--- a/automate/dbt/open_dbt_docs_links_new_tab.py
+++ b/automate/dbt/open_dbt_docs_links_new_tab.py
@@ -1,12 +1,19 @@
 import os
 from pathlib import Path
 
+from rich import console
+
+console = console.Console()
+
 DBT_HOME = os.environ.get("DBT_HOME", "/config/workspace/transform")
 
 dbt_docs_index_path = Path(f"{DBT_HOME}/target/index.html")
 
 if not dbt_docs_index_path.exists():
-    raise Exception("DBT docs not generated")
+    console.print(
+        "[red]:cross_mark:[/red] DBT docs not found, run [i]'dbt docs generate'[/i] in your project folder"
+    )
+    exit(1)
 
 with open(dbt_docs_index_path, "r") as f:
     html_content = f.read()
@@ -22,5 +29,10 @@ if new_tab_tag not in html_content[head_start:head_end]:
     # Write the modified content back to the HTML file
     with open(dbt_docs_index_path, "w") as html_file:
         html_file.write(modified_content)
+    console.print(
+        "[green]:heavy_check_mark:[/green] dbt docs links will now open in a new tab"
+    )
 else:
-    print("New-tab tag already exists in the dbt-docs page.")
+    console.print(
+        "[red]:cross_mark:[/red] dbt-docs links are already being opened in a new tab."
+    )

--- a/automate/dbt/open_dbt_docs_links_new_tab.py
+++ b/automate/dbt/open_dbt_docs_links_new_tab.py
@@ -1,3 +1,10 @@
+#!/usr/bin/env python
+
+# This script is used to enable linking to external resources by updating descriptions
+# example:
+#    description: Current Population by Country [Read more](https://www.google.com/)
+
+
 import os
 from pathlib import Path
 
@@ -11,7 +18,7 @@ dbt_docs_index_path = Path(f"{DBT_HOME}/target/index.html")
 
 if not dbt_docs_index_path.exists():
     console.print(
-        "[red]:cross_mark:[/red] DBT docs not found, run [i]'dbt docs generate'[/i] in your project folder"
+        "[red]:cross_mark:[/red] dbt docs not found, run [i]'dbt docs generate'[/i] first"
     )
 else:
     with open(dbt_docs_index_path, "r") as f:


### PR DESCRIPTION
This PR adds a script in `automate/dbt/open_dbt_docs_links_new_tab.py`, which adds the `<base target=_blank>` to dbt-docs' index in `{DBT_HOME}/target/index.html`

- If dbt docs weren't generated (index is not found), an error is raised prompting the user to run `dbt docs generate`
- if `<base>` addition is successful, the user is informed
- if `<base>` is already present in dbt docs index, an error is raised

Testing steps:
- Generate dbt docs in Datacoves and use a link: content will try to be opened in the iFrame itself
- Run this script: links should now be opened in a new tab 


